### PR TITLE
Re-order Struct

### DIFF
--- a/src/onewire_master_protocol.h
+++ b/src/onewire_master_protocol.h
@@ -202,9 +202,9 @@ typedef struct {
 
 typedef struct {
     U8 alive;
-    SNHub_Api_Provision_t info;
     U8 snsrnum;
     U8 snsrlist[8];
+    SNHub_Api_Provision_t info;
 } ATT_PACKED SNHub_Record_t;
 
 typedef struct {


### PR DESCRIPTION
After a toolchain update, compilation is failing with  ``.pio/libdeps/rak2560/RAK-OneWireSerial/src/onewire_master_protocol.h:185:14: error: flexible array member 'SNHub_Api_Provision_t::snsr_type' not at end of 'struct<unnamed>'``

It seems that a simple re-ordering of a struct fixes the issue. This is compile tested only for now.